### PR TITLE
Add volume range config

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -57,8 +57,8 @@ The following configuration values are available:
   For example try ``min_volume = 30`` and ``max_volume = 70`` to map Mopidy's volume control to the middle
   of ALSA's volume range.
 
-- ``alsamixer/volume_scale``: Either 'linear', 'cubic' or 'log'. The cubic scale is recommended as it produces
-  better results to the ear, and matches the volume scale in alsamixer. The default is the linear scale.
+- ``alsamixer/volume_scale``: Either 'linear', 'cubic' or 'log'. The cubic scale is the default as it produces
+  better results to the ear, and matches the volume scale in alsamixer.
 
 Example ``alsamixer`` section from the Mopidy configuration file::
 
@@ -67,7 +67,7 @@ Example ``alsamixer`` section from the Mopidy configuration file::
     control = PCM
     min_volume = 0
     max_volume = 100
-    volume_scale = linear
+    volume_scale = cubic
 
 Project resources
 =================

--- a/README.rst
+++ b/README.rst
@@ -57,8 +57,8 @@ The following configuration values are available:
   For example try ``min_volume = 30`` and ``max_volume = 70`` to map Mopidy's volume control to the middle
   of ALSA's volume range.
 
-- ``alsamixer/logarithmic_volume``: Use a logarithmic volume scale. This is recommended with the current
-  version of pyalsaaudio, which provides a linear volume scale, whereas volume should be logarithmic.
+- ``alsamixer/volume_scale``: Either 'linear' or 'cubic'. The cubic scale is recommended as it produces
+  better results to the ear, and matches the volume scale in alsamixer. The default is the linear scale.
 
 Example ``alsamixer`` section from the Mopidy configuration file::
 
@@ -67,7 +67,7 @@ Example ``alsamixer`` section from the Mopidy configuration file::
     control = PCM
     min_volume = 0
     max_volume = 100
-    logarithmic_volume = false
+    volume_scale = linear
 
 Project resources
 =================

--- a/README.rst
+++ b/README.rst
@@ -57,7 +57,7 @@ The following configuration values are available:
   For example try ``min_volume = 30`` and ``max_volume = 70`` to map Mopidy's volume control to the middle
   of ALSA's volume range.
 
-- ``alsamixer/volume_scale``: Either 'linear' or 'cubic'. The cubic scale is recommended as it produces
+- ``alsamixer/volume_scale``: Either 'linear', 'cubic' or 'db'. The cubic scale is recommended as it produces
   better results to the ear, and matches the volume scale in alsamixer. The default is the linear scale.
 
 Example ``alsamixer`` section from the Mopidy configuration file::

--- a/README.rst
+++ b/README.rst
@@ -57,7 +57,7 @@ The following configuration values are available:
   For example try ``min_volume = 30`` and ``max_volume = 70`` to map Mopidy's volume control to the middle
   of ALSA's volume range.
 
-- ``alsamixer/volume_scale``: Either 'linear', 'cubic' or 'db'. The cubic scale is recommended as it produces
+- ``alsamixer/volume_scale``: Either 'linear', 'cubic' or 'log'. The cubic scale is recommended as it produces
   better results to the ear, and matches the volume scale in alsamixer. The default is the linear scale.
 
 Example ``alsamixer`` section from the Mopidy configuration file::

--- a/README.rst
+++ b/README.rst
@@ -51,11 +51,19 @@ The following configuration values are available:
   Other typical values includes ``PCM``. Run the command ``amixer scontrols``
   to list available controls on your system.
 
+- ``alsamixer/volmin`` and ``alsamixer/volmax``: Map the Mopidy volume control range to
+  a different range. Values are in the range 0-100. Use this if the default range (0 - 100)
+  is too wide, resulting in a small usable range for Mopidy's volume control.
+  For example try ``volmin = 30`` and ``volmin = 70`` to map Mopidy's volume control to the middle
+  of ALSA's volume range.
+
 Example ``alsamixer`` section from the Mopidy configuration file::
 
     [alsamixer]
     card = 1
     control = PCM
+    volmin = 0
+    volmin = 100
 
 
 Project resources

--- a/README.rst
+++ b/README.rst
@@ -57,6 +57,9 @@ The following configuration values are available:
   For example try ``volmin = 30`` and ``volmin = 70`` to map Mopidy's volume control to the middle
   of ALSA's volume range.
 
+- ``alsamixer/logarithmic_volume``: Use a logarithmic volume scale. This is recommended with the current
+  version of pyalsaaudio, which provides a linear volume scale, whereas volume should be logarithmic.
+
 Example ``alsamixer`` section from the Mopidy configuration file::
 
     [alsamixer]
@@ -64,7 +67,7 @@ Example ``alsamixer`` section from the Mopidy configuration file::
     control = PCM
     volmin = 0
     volmin = 100
-
+    logarithmic_volume = false
 
 Project resources
 =================

--- a/README.rst
+++ b/README.rst
@@ -51,10 +51,10 @@ The following configuration values are available:
   Other typical values includes ``PCM``. Run the command ``amixer scontrols``
   to list available controls on your system.
 
-- ``alsamixer/volmin`` and ``alsamixer/volmax``: Map the Mopidy volume control range to
+- ``alsamixer/min_volume`` and ``alsamixer/max_volume``: Map the Mopidy volume control range to
   a different range. Values are in the range 0-100. Use this if the default range (0 - 100)
   is too wide, resulting in a small usable range for Mopidy's volume control.
-  For example try ``volmin = 30`` and ``volmin = 70`` to map Mopidy's volume control to the middle
+  For example try ``min_volume = 30`` and ``max_volume = 70`` to map Mopidy's volume control to the middle
   of ALSA's volume range.
 
 - ``alsamixer/logarithmic_volume``: Use a logarithmic volume scale. This is recommended with the current
@@ -65,8 +65,8 @@ Example ``alsamixer`` section from the Mopidy configuration file::
     [alsamixer]
     card = 1
     control = PCM
-    volmin = 0
-    volmin = 100
+    min_volume = 0
+    max_volume = 100
     logarithmic_volume = false
 
 Project resources

--- a/mopidy_alsamixer/__init__.py
+++ b/mopidy_alsamixer/__init__.py
@@ -24,6 +24,7 @@ class Extension(ext.Extension):
         schema['control'] = config.String()
         schema['volmin'] = config.Integer(minimum=0, maximum=100)
         schema['volmax'] = config.Integer(minimum=0, maximum=100)
+        schema['logarithmic_volume'] = config.Boolean()
         return schema
 
     def setup(self, registry):

--- a/mopidy_alsamixer/__init__.py
+++ b/mopidy_alsamixer/__init__.py
@@ -22,8 +22,8 @@ class Extension(ext.Extension):
         schema = super(Extension, self).get_config_schema()
         schema['card'] = config.Integer(minimum=0)
         schema['control'] = config.String()
-        schema['volmin'] = config.Integer(minimum=0, maximum=100)
-        schema['volmax'] = config.Integer(minimum=0, maximum=100)
+        schema['min_volume'] = config.Integer(minimum=0, maximum=100)
+        schema['max_volume'] = config.Integer(minimum=0, maximum=100)
         schema['logarithmic_volume'] = config.Boolean()
         return schema
 

--- a/mopidy_alsamixer/__init__.py
+++ b/mopidy_alsamixer/__init__.py
@@ -24,7 +24,7 @@ class Extension(ext.Extension):
         schema['control'] = config.String()
         schema['min_volume'] = config.Integer(minimum=0, maximum=100)
         schema['max_volume'] = config.Integer(minimum=0, maximum=100)
-        schema['logarithmic_volume'] = config.Boolean()
+        schema['volume_scale'] = config.String(choices=('linear', 'cubic'))
         return schema
 
     def setup(self, registry):

--- a/mopidy_alsamixer/__init__.py
+++ b/mopidy_alsamixer/__init__.py
@@ -22,6 +22,8 @@ class Extension(ext.Extension):
         schema = super(Extension, self).get_config_schema()
         schema['card'] = config.Integer(minimum=0)
         schema['control'] = config.String()
+        schema['volmin'] = config.Integer(minimum=0, maximum=100)
+        schema['volmax'] = config.Integer(minimum=0, maximum=100)
         return schema
 
     def setup(self, registry):

--- a/mopidy_alsamixer/__init__.py
+++ b/mopidy_alsamixer/__init__.py
@@ -24,7 +24,7 @@ class Extension(ext.Extension):
         schema['control'] = config.String()
         schema['min_volume'] = config.Integer(minimum=0, maximum=100)
         schema['max_volume'] = config.Integer(minimum=0, maximum=100)
-        schema['volume_scale'] = config.String(choices=('linear', 'cubic'))
+        schema['volume_scale'] = config.String(choices=('linear', 'cubic', 'db'))
         return schema
 
     def setup(self, registry):

--- a/mopidy_alsamixer/__init__.py
+++ b/mopidy_alsamixer/__init__.py
@@ -24,7 +24,7 @@ class Extension(ext.Extension):
         schema['control'] = config.String()
         schema['min_volume'] = config.Integer(minimum=0, maximum=100)
         schema['max_volume'] = config.Integer(minimum=0, maximum=100)
-        schema['volume_scale'] = config.String(choices=('linear', 'cubic', 'db'))
+        schema['volume_scale'] = config.String(choices=('linear', 'cubic', 'log'))
         return schema
 
     def setup(self, registry):

--- a/mopidy_alsamixer/__init__.py
+++ b/mopidy_alsamixer/__init__.py
@@ -24,7 +24,8 @@ class Extension(ext.Extension):
         schema['control'] = config.String()
         schema['min_volume'] = config.Integer(minimum=0, maximum=100)
         schema['max_volume'] = config.Integer(minimum=0, maximum=100)
-        schema['volume_scale'] = config.String(choices=('linear', 'cubic', 'log'))
+        schema['volume_scale'] = config.String(
+            choices=('linear', 'cubic', 'log'))
         return schema
 
     def setup(self, registry):

--- a/mopidy_alsamixer/ext.conf
+++ b/mopidy_alsamixer/ext.conf
@@ -2,6 +2,6 @@
 enabled = true
 card = 0
 control = Master
-volmin = 0
-volmax = 100
+min_volume = 0
+max_volume = 100
 logarithmic_volume = false

--- a/mopidy_alsamixer/ext.conf
+++ b/mopidy_alsamixer/ext.conf
@@ -4,3 +4,4 @@ card = 0
 control = Master
 volmin = 0
 volmax = 100
+logarithmic_volume = false

--- a/mopidy_alsamixer/ext.conf
+++ b/mopidy_alsamixer/ext.conf
@@ -4,4 +4,4 @@ card = 0
 control = Master
 min_volume = 0
 max_volume = 100
-logarithmic_volume = false
+volume_scale = linear

--- a/mopidy_alsamixer/ext.conf
+++ b/mopidy_alsamixer/ext.conf
@@ -2,3 +2,5 @@
 enabled = true
 card = 0
 control = Master
+volmin = 0
+volmax = 100

--- a/mopidy_alsamixer/ext.conf
+++ b/mopidy_alsamixer/ext.conf
@@ -4,4 +4,4 @@ card = 0
 control = Master
 min_volume = 0
 max_volume = 100
-volume_scale = linear
+volume_scale = cubic

--- a/mopidy_alsamixer/mixer.py
+++ b/mopidy_alsamixer/mixer.py
@@ -24,8 +24,8 @@ class AlsaMixer(pykka.ThreadingActor, mixer.Mixer):
         self.config = config
         self.card = self.config['alsamixer']['card']
         self.control = self.config['alsamixer']['control']
-        self.volmin = self.config['alsamixer']['volmin']
-        self.volmax = self.config['alsamixer']['volmax']
+        self.min_volume = self.config['alsamixer']['min_volume']
+        self.max_volume = self.config['alsamixer']['max_volume']
         self.logarithmic_volume = self.config['alsamixer']['logarithmic_volume']
 
         known_cards = alsaaudio.cards()
@@ -77,14 +77,14 @@ class AlsaMixer(pykka.ThreadingActor, mixer.Mixer):
             unadjusted_volume = channels[0]
             if self.logarithmic_volume:
                 unadjusted_volume = 100.0 * math.pow(unadjusted_volume / 100.0, 3.0)
-            unadjusted_volume = (unadjusted_volume - self.volmin) * 100.0 / (self.volmax - self.volmin)
+            unadjusted_volume = (unadjusted_volume - self.min_volume) * 100.0 / (self.max_volume - self.min_volume)
             return int(unadjusted_volume)
         else:
             # Not all channels have the same volume
             return None
 
     def set_volume(self, volume):
-        adjusted_volume = self.volmin + volume * (self.volmax - self.volmin) / 100.0
+        adjusted_volume = self.min_volume + volume * (self.max_volume - self.min_volume) / 100.0
         if self.logarithmic_volume:
             adjusted_volume = 100.0 * math.pow(adjusted_volume / 100.0, 1.0 / 3.0)
         self._mixer.setvolume(int(adjusted_volume))

--- a/mopidy_alsamixer/mixer.py
+++ b/mopidy_alsamixer/mixer.py
@@ -26,7 +26,7 @@ class AlsaMixer(pykka.ThreadingActor, mixer.Mixer):
         self.control = self.config['alsamixer']['control']
         self.min_volume = self.config['alsamixer']['min_volume']
         self.max_volume = self.config['alsamixer']['max_volume']
-        self.logarithmic_volume = self.config['alsamixer']['logarithmic_volume']
+        self.volume_scale = self.config['alsamixer']['volume_scale']
 
         known_cards = alsaaudio.cards()
         if self.card >= len(known_cards):
@@ -75,7 +75,7 @@ class AlsaMixer(pykka.ThreadingActor, mixer.Mixer):
             return None
         elif channels.count(channels[0]) == len(channels):
             unadjusted_volume = channels[0]
-            if self.logarithmic_volume:
+            if self.volume_scale == "cubic":
                 unadjusted_volume = 100.0 * math.pow(unadjusted_volume / 100.0, 3.0)
             unadjusted_volume = (unadjusted_volume - self.min_volume) * 100.0 / (self.max_volume - self.min_volume)
             return int(unadjusted_volume)
@@ -85,7 +85,7 @@ class AlsaMixer(pykka.ThreadingActor, mixer.Mixer):
 
     def set_volume(self, volume):
         adjusted_volume = self.min_volume + volume * (self.max_volume - self.min_volume) / 100.0
-        if self.logarithmic_volume:
+        if self.volume_scale == "cubic":
             adjusted_volume = 100.0 * math.pow(adjusted_volume / 100.0, 1.0 / 3.0)
         self._mixer.setvolume(int(adjusted_volume))
         return True

--- a/mopidy_alsamixer/mixer.py
+++ b/mopidy_alsamixer/mixer.py
@@ -89,28 +89,34 @@ class AlsaMixer(pykka.ThreadingActor, mixer.Mixer):
         volume = mixer_volume
         if self.volume_scale == "cubic":
             volume = GstAudio.StreamVolume.convert_volume(
-                GstAudio.StreamVolumeFormat.CUBIC, 
-                GstAudio.StreamVolumeFormat.LINEAR, 
+                GstAudio.StreamVolumeFormat.CUBIC,
+                GstAudio.StreamVolumeFormat.LINEAR,
                 volume / 100.0) * 100.0
         elif self.volume_scale == "log":
-            # Uses our own formula rather than GstAudio.StreamVolume.convert_volume(GstAudio.StreamVolumeFormat.LINEAR, GstAudio.StreamVolumeFormat.DB, mixer_volume / 100.0)
-            # as the result is a DB value, which we can't work with as self._mixer provides a percentage.
+            # Uses our own formula rather than GstAudio.StreamVolume.
+            # convert_volume(GstAudio.StreamVolumeFormat.LINEAR,
+            # GstAudio.StreamVolumeFormat.DB, mixer_volume / 100.0)
+            # as the result is a DB value, which we can't work with as
+            # self._mixer provides a percentage.
             volume = math.pow(10, volume / 50.0)
-        volume = (volume - self.min_volume) * 100.0 / 
-            (self.max_volume - self.min_volume)
+        volume = ((volume - self.min_volume) * 100.0
+                  / (self.max_volume - self.min_volume))
         return int(volume)
 
     def volume_to_mixer_volume(self, volume):
-        mixer_volume = self.min_volume + volume * 
-            (self.max_volume - self.min_volume) / 100.0
+        mixer_volume = (self.min_volume + volume *
+                        (self.max_volume - self.min_volume) / 100.0)
         if self.volume_scale == "cubic":
             mixer_volume = GstAudio.StreamVolume.convert_volume(
-                GstAudio.StreamVolumeFormat.LINEAR, 
-                GstAudio.StreamVolumeFormat.CUBIC, 
+                GstAudio.StreamVolumeFormat.LINEAR,
+                GstAudio.StreamVolumeFormat.CUBIC,
                 mixer_volume / 100.0) * 100.0
         elif self.volume_scale == "log":
-            # Uses our own formula rather than GstAudio.StreamVolume.convert_volume(GstAudio.StreamVolumeFormat.LINEAR, GstAudio.StreamVolumeFormat.DB, mixer_volume / 100.0)
-            # as the result is a DB value, which we can't work with as self._mixer wants a percentage.
+            # Uses our own formula rather than GstAudio.StreamVolume.
+            # convert_volume(GstAudio.StreamVolumeFormat.LINEAR,
+            # GstAudio.StreamVolumeFormat.DB, mixer_volume / 100.0)
+            # as the result is a DB value, which we can't work with as
+            # self._mixer wants a percentage.
             mixer_volume = 50 * math.log10(mixer_volume)
         return int(mixer_volume)
 

--- a/mopidy_alsamixer/mixer.py
+++ b/mopidy_alsamixer/mixer.py
@@ -88,6 +88,9 @@ class AlsaMixer(pykka.ThreadingActor, mixer.Mixer):
         volume = mixer_volume
         if self.volume_scale == "cubic":
             volume = GstAudio.StreamVolume.convert_volume(GstAudio.StreamVolumeFormat.CUBIC, GstAudio.StreamVolumeFormat.LINEAR, volume / 100.0) * 100.0
+        elif self.volume_scale == "db":
+            volume = math.pow(10, volume / 50.0)
+            #volume = GstAudio.StreamVolume.convert_volume(GstAudio.StreamVolumeFormat.DB, GstAudio.StreamVolumeFormat.LINEAR, volume / 100.0) * 100.0
         volume = (volume - self.min_volume) * 100.0 / (self.max_volume - self.min_volume)
         return int(volume)
 
@@ -95,6 +98,9 @@ class AlsaMixer(pykka.ThreadingActor, mixer.Mixer):
         mixer_volume = self.min_volume + volume * (self.max_volume - self.min_volume) / 100.0
         if self.volume_scale == "cubic":
             mixer_volume = GstAudio.StreamVolume.convert_volume(GstAudio.StreamVolumeFormat.LINEAR, GstAudio.StreamVolumeFormat.CUBIC, mixer_volume / 100.0) * 100.0
+        elif self.volume_scale == "db":
+            mixer_volume = 50 * math.log10(mixer_volume)
+            #mixer_volume = GstAudio.StreamVolume.convert_volume(GstAudio.StreamVolumeFormat.LINEAR, GstAudio.StreamVolumeFormat.DB, mixer_volume / 100.0)
         return int(mixer_volume)
 
     def get_mute(self):

--- a/mopidy_alsamixer/mixer.py
+++ b/mopidy_alsamixer/mixer.py
@@ -89,8 +89,9 @@ class AlsaMixer(pykka.ThreadingActor, mixer.Mixer):
         if self.volume_scale == "cubic":
             volume = GstAudio.StreamVolume.convert_volume(GstAudio.StreamVolumeFormat.CUBIC, GstAudio.StreamVolumeFormat.LINEAR, volume / 100.0) * 100.0
         elif self.volume_scale == "db":
+            # Uses our own formula rather than GstAudio.StreamVolume.convert_volume(GstAudio.StreamVolumeFormat.LINEAR, GstAudio.StreamVolumeFormat.DB, mixer_volume / 100.0)
+            # as the result is a DB value, which we can't work with as self._mixer provides a percentage.
             volume = math.pow(10, volume / 50.0)
-            #volume = GstAudio.StreamVolume.convert_volume(GstAudio.StreamVolumeFormat.DB, GstAudio.StreamVolumeFormat.LINEAR, volume / 100.0) * 100.0
         volume = (volume - self.min_volume) * 100.0 / (self.max_volume - self.min_volume)
         return int(volume)
 
@@ -99,8 +100,9 @@ class AlsaMixer(pykka.ThreadingActor, mixer.Mixer):
         if self.volume_scale == "cubic":
             mixer_volume = GstAudio.StreamVolume.convert_volume(GstAudio.StreamVolumeFormat.LINEAR, GstAudio.StreamVolumeFormat.CUBIC, mixer_volume / 100.0) * 100.0
         elif self.volume_scale == "db":
+            # Uses our own formula rather than GstAudio.StreamVolume.convert_volume(GstAudio.StreamVolumeFormat.LINEAR, GstAudio.StreamVolumeFormat.DB, mixer_volume / 100.0)
+            # as the result is a DB value, which we can't work with as self._mixer wants a percentage.
             mixer_volume = 50 * math.log10(mixer_volume)
-            #mixer_volume = GstAudio.StreamVolume.convert_volume(GstAudio.StreamVolumeFormat.LINEAR, GstAudio.StreamVolumeFormat.DB, mixer_volume / 100.0)
         return int(mixer_volume)
 
     def get_mute(self):

--- a/mopidy_alsamixer/mixer.py
+++ b/mopidy_alsamixer/mixer.py
@@ -88,7 +88,7 @@ class AlsaMixer(pykka.ThreadingActor, mixer.Mixer):
         volume = mixer_volume
         if self.volume_scale == "cubic":
             volume = GstAudio.StreamVolume.convert_volume(GstAudio.StreamVolumeFormat.CUBIC, GstAudio.StreamVolumeFormat.LINEAR, volume / 100.0) * 100.0
-        elif self.volume_scale == "db":
+        elif self.volume_scale == "log":
             # Uses our own formula rather than GstAudio.StreamVolume.convert_volume(GstAudio.StreamVolumeFormat.LINEAR, GstAudio.StreamVolumeFormat.DB, mixer_volume / 100.0)
             # as the result is a DB value, which we can't work with as self._mixer provides a percentage.
             volume = math.pow(10, volume / 50.0)
@@ -99,7 +99,7 @@ class AlsaMixer(pykka.ThreadingActor, mixer.Mixer):
         mixer_volume = self.min_volume + volume * (self.max_volume - self.min_volume) / 100.0
         if self.volume_scale == "cubic":
             mixer_volume = GstAudio.StreamVolume.convert_volume(GstAudio.StreamVolumeFormat.LINEAR, GstAudio.StreamVolumeFormat.CUBIC, mixer_volume / 100.0) * 100.0
-        elif self.volume_scale == "db":
+        elif self.volume_scale == "log":
             # Uses our own formula rather than GstAudio.StreamVolume.convert_volume(GstAudio.StreamVolumeFormat.LINEAR, GstAudio.StreamVolumeFormat.DB, mixer_volume / 100.0)
             # as the result is a DB value, which we can't work with as self._mixer wants a percentage.
             mixer_volume = 50 * math.log10(mixer_volume)

--- a/mopidy_alsamixer/mixer.py
+++ b/mopidy_alsamixer/mixer.py
@@ -6,6 +6,7 @@ import threading
 import math
 
 import alsaaudio
+from gi.repository import GstAudio
 
 from mopidy import exceptions, mixer
 
@@ -86,14 +87,14 @@ class AlsaMixer(pykka.ThreadingActor, mixer.Mixer):
     def mixer_volume_to_volume(self, mixer_volume):
         volume = mixer_volume
         if self.volume_scale == "cubic":
-            volume = 100.0 * math.pow(volume / 100.0, 3.0)
+            volume = GstAudio.StreamVolume.convert_volume(GstAudio.StreamVolumeFormat.CUBIC, GstAudio.StreamVolumeFormat.LINEAR, volume / 100.0) * 100.0
         volume = (volume - self.min_volume) * 100.0 / (self.max_volume - self.min_volume)
         return int(volume)
 
     def volume_to_mixer_volume(self, volume):
         mixer_volume = self.min_volume + volume * (self.max_volume - self.min_volume) / 100.0
         if self.volume_scale == "cubic":
-            mixer_volume = 100.0 * math.pow(mixer_volume / 100.0, 1.0 / 3.0)
+            mixer_volume = GstAudio.StreamVolume.convert_volume(GstAudio.StreamVolumeFormat.LINEAR, GstAudio.StreamVolumeFormat.CUBIC, mixer_volume / 100.0) * 100.0
         return int(mixer_volume)
 
     def get_mute(self):

--- a/tests/test_mixer.py
+++ b/tests/test_mixer.py
@@ -20,7 +20,11 @@ class MixerTest(unittest.TestCase):
         if alsa_mock is not None:
             alsa_mock.cards.return_value = ['PCH']
             alsa_mock.mixers.return_value = ['Master']
-        return AlsaMixer(config=config)
+        actual_config = {'alsamixer': {'card': 0, 'control': 'Master',
+                         'min_volume': 0, 'max_volume': 100,
+                         'volume_scale': 'cubic'}}
+        actual_config.update(config)
+        return AlsaMixer(config=actual_config)
 
     def test_has_config(self, alsa_mock):
         config = {'alsamixer': {'card': 0, 'control': 'Master'}}

--- a/tests/test_mixer.py
+++ b/tests/test_mixer.py
@@ -97,6 +97,16 @@ class MixerTest(unittest.TestCase):
 
         mixer_mock.getvolume.assert_called_once_with()
 
+    def test_get_volume_log(self, alsa_mock):
+        config = {'alsamixer': {'volume_scale': 'log'}}
+        mixer = self.get_mixer(alsa_mock, config=config)
+        mixer_mock = alsa_mock.Mixer.return_value
+        mixer_mock.getvolume.return_value = [86]
+
+        self.assertEqual(mixer.get_volume(), 52)
+
+        mixer_mock.getvolume.assert_called_once_with()
+
     def test_get_volume_when_channels_are_different(self, alsa_mock):
         mixer = self.get_mixer(alsa_mock)
         mixer_mock = alsa_mock.Mixer.return_value
@@ -132,6 +142,15 @@ class MixerTest(unittest.TestCase):
         self.assertTrue(mixer.set_volume(74))
 
         mixer_mock.setvolume.assert_called_once_with(90)
+
+    def test_set_volume_log(self, alsa_mock):
+        config = {'alsamixer': {'volume_scale': 'log'}}
+        mixer = self.get_mixer(alsa_mock, config=config)
+        mixer_mock = alsa_mock.Mixer.return_value
+
+        self.assertTrue(mixer.set_volume(74))
+
+        mixer_mock.setvolume.assert_called_once_with(93)
 
     def test_get_mute_when_muted(self, alsa_mock):
         mixer = self.get_mixer(alsa_mock)

--- a/tests/test_mixer.py
+++ b/tests/test_mixer.py
@@ -19,7 +19,8 @@ class MixerTest(unittest.TestCase):
                        'min_volume': 0, 'max_volume': 100,
                        'volume_scale': 'cubic'}}
 
-    def get_mixer(self, alsa_mock=None, config=None, apply_default_config=True):
+    def get_mixer(self, alsa_mock=None, config=None,
+                  apply_default_config=True):
         if config is None:
             config = {'alsamixer': {'card': 0, 'control': 'Master'}}
         if alsa_mock is not None:
@@ -37,7 +38,8 @@ class MixerTest(unittest.TestCase):
         actual_config = MixerTest.default_config.copy()
         actual_config['alsamixer'].update(config['alsamixer'])
 
-        mixer = self.get_mixer(alsa_mock, config=actual_config, apply_default_config=False)
+        mixer = self.get_mixer(alsa_mock, config=actual_config,
+                               apply_default_config=False)
         self.assertIs(mixer.config, actual_config)
 
     def test_use_card_from_config(self, alsa_mock):

--- a/tests/test_mixer.py
+++ b/tests/test_mixer.py
@@ -85,6 +85,16 @@ class MixerTest(unittest.TestCase):
 
         mixer_mock.getvolume.assert_called_once_with()
 
+    def test_get_volume_cubic(self, alsa_mock):
+        config = {'alsamixer': {'volume_scale': 'cubic'}}
+        mixer = self.get_mixer(alsa_mock, config=config)
+        mixer_mock = alsa_mock.Mixer.return_value
+        mixer_mock.getvolume.return_value = [86]
+
+        self.assertEqual(mixer.get_volume(), 63)
+
+        mixer_mock.getvolume.assert_called_once_with()
+
     def test_get_volume_when_channels_are_different(self, alsa_mock):
         mixer = self.get_mixer(alsa_mock)
         mixer_mock = alsa_mock.Mixer.return_value
@@ -111,6 +121,15 @@ class MixerTest(unittest.TestCase):
         self.assertTrue(mixer.set_volume(74))
 
         mixer_mock.setvolume.assert_called_once_with(74)
+
+    def test_set_volume_cubic(self, alsa_mock):
+        config = {'alsamixer': {'volume_scale': 'cubic'}}
+        mixer = self.get_mixer(alsa_mock, config=config)
+        mixer_mock = alsa_mock.Mixer.return_value
+
+        self.assertTrue(mixer.set_volume(74))
+
+        mixer_mock.setvolume.assert_called_once_with(90)
 
     def test_get_mute_when_muted(self, alsa_mock):
         mixer = self.get_mixer(alsa_mock)

--- a/tests/test_mixer.py
+++ b/tests/test_mixer.py
@@ -20,10 +20,11 @@ class MixerTest(unittest.TestCase):
         if alsa_mock is not None:
             alsa_mock.cards.return_value = ['PCH']
             alsa_mock.mixers.return_value = ['Master']
-        actual_config = {'alsamixer': {'card': 0, 'control': 'Master',
-                         'min_volume': 0, 'max_volume': 100,
-                         'volume_scale': 'cubic'}}
-        actual_config.update(config)
+        actual_config = {'alsamixer':
+                         {'card': 0, 'control': 'Master',
+                          'min_volume': 0, 'max_volume': 100,
+                          'volume_scale': 'cubic'}}
+        actual_config['alsamixer'].update(config['alsamixer'])
         return AlsaMixer(config=actual_config)
 
     def test_has_config(self, alsa_mock):


### PR DESCRIPTION
This helps with https://github.com/mopidy/mopidy-alsamixer/issues/3

This doesn't do anything logarithmic with the volume, although it would be easy to do so as the code is pretty simple. As noted in the issue above, perhaps that is best done in pyalsaaudio but making changes there seemed a bit broader! This approach works for me at the moment.

Apologies, this is my first time writing Python.