### PR TITLE
Allow user to select device of soundcard

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -62,7 +62,7 @@ The following configuration values are available:
   cubic scale is the default as it is closer to how the human ear percieves
   volume, and matches the volume scale used in the ``alsamixer`` program.
   
--``alsamixer/device``: select what device number you want to use. 
+- ``alsamixer/device``: select what device number you want to use. 
 Numbered from 0 and up. 0 is the default.
 
 Example ``alsamixer`` section from the Mopidy configuration file::

--- a/README.rst
+++ b/README.rst
@@ -62,8 +62,7 @@ The following configuration values are available:
   cubic scale is the default as it is closer to how the human ear percieves
   volume, and matches the volume scale used in the ``alsamixer`` program.
   
-- ``alsamixer/device``: select what device number you want to use. 
-Numbered from 0 and up. 0 is the default.
+- ``alsamixer/device``: select what device number you want to use. Numbered from 0 and up. 0 is the default.
 
 Example ``alsamixer`` section from the Mopidy configuration file::
 

--- a/README.rst
+++ b/README.rst
@@ -61,6 +61,9 @@ The following configuration values are available:
 - ``alsamixer/volume_scale``: Either ``linear``, ``cubic``, or ``log``. The
   cubic scale is the default as it is closer to how the human ear percieves
   volume, and matches the volume scale used in the ``alsamixer`` program.
+  
+-``alsamixer/device``: select what device number you want to use. 
+Numbered from 0 and up. 0 is the default.
 
 Example ``alsamixer`` section from the Mopidy configuration file::
 
@@ -70,6 +73,7 @@ Example ``alsamixer`` section from the Mopidy configuration file::
     min_volume = 0
     max_volume = 100
     volume_scale = cubic
+    device = 1
 
 Project resources
 =================

--- a/mopidy_alsamixer/__init__.py
+++ b/mopidy_alsamixer/__init__.py
@@ -21,6 +21,7 @@ class Extension(ext.Extension):
     def get_config_schema(self):
         schema = super(Extension, self).get_config_schema()
         schema['card'] = config.Integer(minimum=0)
+        schema['device'] = config.String()
         schema['control'] = config.String()
         schema['min_volume'] = config.Integer(minimum=0, maximum=100)
         schema['max_volume'] = config.Integer(minimum=0, maximum=100)

--- a/mopidy_alsamixer/ext.conf
+++ b/mopidy_alsamixer/ext.conf
@@ -1,6 +1,7 @@
 [alsamixer]
 enabled = true
 card = 0
+device = default
 control = Master
 min_volume = 0
 max_volume = 100

--- a/mopidy_alsamixer/mixer.py
+++ b/mopidy_alsamixer/mixer.py
@@ -57,8 +57,8 @@ class AlsaMixer(pykka.ThreadingActor, mixer.Mixer):
         self._last_mute = None
 
         logger.info(
-            'Mixing using ALSA, card %d, mixer control "%s".',
-            self.cardindex, self.control)
+            'Mixing using ALSA, card %d, mixer control "%s", device "%s".',
+            self.cardindex, self.control, self.device)
 
     def on_start(self):
         self._observer = AlsaMixerObserver(


### PR DESCRIPTION
This pull requests allows a user to select a given device when selecting a sound card. The device number can be set using the ``alsamixer/device`` config option.