### PR TITLE
introduced mixer control id

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -51,6 +51,8 @@ The following configuration values are available:
   Other typical values includes ``PCM``. Run the command ``amixer scontrols``
   to list available controls on your system.
 
+- ``alsamixer/mixerid``: the id of the mixer control. Default is 0.
+
 - ``alsamixer/min_volume`` and ``alsamixer/max_volume``: Map the Mopidy volume
   control range to a different range. Values are in the range 0-100. Use this
   if the default range (0-100) is too wide, resulting in a small usable range
@@ -67,6 +69,7 @@ Example ``alsamixer`` section from the Mopidy configuration file::
     [alsamixer]
     card = 1
     control = PCM
+    mixerid = 0
     min_volume = 0
     max_volume = 100
     volume_scale = cubic

--- a/mopidy_alsamixer/__init__.py
+++ b/mopidy_alsamixer/__init__.py
@@ -22,6 +22,7 @@ class Extension(ext.Extension):
         schema = super(Extension, self).get_config_schema()
         schema['card'] = config.Integer(minimum=0)
         schema['control'] = config.String()
+        schema['mixerid'] = config.Integer(minimum=0)
         schema['min_volume'] = config.Integer(minimum=0, maximum=100)
         schema['max_volume'] = config.Integer(minimum=0, maximum=100)
         schema['volume_scale'] = config.String(

--- a/mopidy_alsamixer/ext.conf
+++ b/mopidy_alsamixer/ext.conf
@@ -2,6 +2,7 @@
 enabled = true
 card = 0
 control = Master
+mixerid = 0
 min_volume = 0
 max_volume = 100
 volume_scale = cubic


### PR DESCRIPTION
Introduced a mixerid for audiocards that expose multiple mixers. See Bug https://github.com/mopidy/mopidy-alsamixer/issues/14