### PR TITLE
add check for and format of string declaration in config

### DIFF
--- a/mopidy_alsamixer/mixer.py
+++ b/mopidy_alsamixer/mixer.py
@@ -29,6 +29,9 @@ class AlsaMixer(pykka.ThreadingActor, mixer.Mixer):
         self.max_volume = self.config["alsamixer"]["max_volume"]
         self.volume_scale = self.config["alsamixer"]["volume_scale"]
 
+        if self.control.startswith("'") and self.control.endswith("'"):
+            self.control = self.control[1: -1]
+
         known_cards = alsaaudio.cards()
         try:
             known_controls = alsaaudio.mixers(self.cardindex)


### PR DESCRIPTION
### Problem
it would be helpful to allow for a user to input a control name with trailing and/or leading white spaces, this would allow usage with devices that have such a name. With this code addition, users may input these special names with single quotation marks at the beginning and end.

This would be consistent with the amixer format. On my machine amixer returns the following mixer control names

`$ amixer scontrols`
`Simple mixer control 'nubert xCore USB Audio ',0`
`Simple mixer control 'nubert xCore USB Audio ',1`
#### Mopidy config
the mopidy alsamixer/control config should be as returned from amixer:

`[alsamixer]`
`control = 'nubert xCore USB Audio '`