### PR TITLE
Add string-based soundcard specification (device string)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -48,11 +48,11 @@ To use Mopidy-AlsaMixer the ``audio/mixer`` configuration value must be set to
 The default Mopidy-AlsaMixer configuration will probably work for most use
 cases. If not, the following configuration values are available:
 
-- ``alsamixer/card``: Which soundcard should be used, specified by its index.
-  Numbered from 0 and up. If specified, ``alsamixer/device`` is ignored.
-
 - ``alsamixer/device``: Which soundcard should be used, specified by its string
   alias. Defaults to ``default``.
+
+- ``alsamixer/card``: Which soundcard should be used, specified by its index.
+  Numbered from 0 and up. If specified, ``alsamixer/device`` is ignored.
 
 - ``alsamixer/control``: Which ALSA control should be used. Defaults to ``Master``.
   Other typical values includes ``PCM``. Run the command ``amixer scontrols``

--- a/README.rst
+++ b/README.rst
@@ -48,10 +48,13 @@ To use Mopidy-AlsaMixer the ``audio/mixer`` configuration value must be set to
 The default Mopidy-AlsaMixer configuration will probably work for most use
 cases. If not, the following configuration values are available:
 
-- ``alsamixer/card``: Which soundcard to use, if you have more than one.
-  Numbered from 0 and up. 0 is the default.
+- ``alsamixer/card``: Which soundcard should be used, specified by its index.
+  Numbered from 0 and up. If specified, ``alsamixer/device`` is ignored.
 
-- ``alsamixer/control``: Which ALSA control to use. Defaults to ``Master``.
+- ``alsamixer/device``: Which soundcard should be used, specified by its string
+  alias. Defaults to ``default``.
+
+- ``alsamixer/control``: Which ALSA control should be used. Defaults to ``Master``.
   Other typical values includes ``PCM``. Run the command ``amixer scontrols``
   to list available controls on your system.
 

--- a/mopidy_alsamixer/__init__.py
+++ b/mopidy_alsamixer/__init__.py
@@ -18,7 +18,8 @@ class Extension(ext.Extension):
 
     def get_config_schema(self):
         schema = super().get_config_schema()
-        schema["card"] = config.Integer(minimum=0)
+        schema["card"] = config.Integer(optional=True, minimum=0)
+        schema["device"] = config.String()
         schema["control"] = config.String()
         schema["min_volume"] = config.Integer(minimum=0, maximum=100)
         schema["max_volume"] = config.Integer(minimum=0, maximum=100)

--- a/mopidy_alsamixer/__init__.py
+++ b/mopidy_alsamixer/__init__.py
@@ -18,8 +18,8 @@ class Extension(ext.Extension):
 
     def get_config_schema(self):
         schema = super().get_config_schema()
-        schema["card"] = config.Integer(optional=True, minimum=0)
         schema["device"] = config.String()
+        schema["card"] = config.Integer(optional=True, minimum=0)
         schema["control"] = config.String()
         schema["min_volume"] = config.Integer(minimum=0, maximum=100)
         schema["max_volume"] = config.Integer(minimum=0, maximum=100)

--- a/mopidy_alsamixer/ext.conf
+++ b/mopidy_alsamixer/ext.conf
@@ -1,7 +1,7 @@
 [alsamixer]
 enabled = true
-card =
 device = default
+card =
 control = Master
 min_volume = 0
 max_volume = 100

--- a/mopidy_alsamixer/ext.conf
+++ b/mopidy_alsamixer/ext.conf
@@ -1,6 +1,7 @@
 [alsamixer]
 enabled = true
-card = 0
+card =
+device = default
 control = Master
 min_volume = 0
 max_volume = 100

--- a/mopidy_alsamixer/mixer.py
+++ b/mopidy_alsamixer/mixer.py
@@ -24,26 +24,34 @@ class AlsaMixer(pykka.ThreadingActor, mixer.Mixer):
         super().__init__()
         self.config = config
         self.cardindex = self.config["alsamixer"]["card"]
+        self.device = self.config["alsamixer"]["device"]
         self.control = self.config["alsamixer"]["control"]
         self.min_volume = self.config["alsamixer"]["min_volume"]
         self.max_volume = self.config["alsamixer"]["max_volume"]
         self.volume_scale = self.config["alsamixer"]["volume_scale"]
 
+        if self.cardindex is not None:
+            cardname = f"soundcard with index {self.cardindex:d}"
+        else:
+            cardname = f"soundcard with name '{self.device}'"
+
         known_cards = alsaaudio.cards()
         try:
-            known_controls = alsaaudio.mixers(self.cardindex)
+            if self.cardindex is not None:
+                known_controls = alsaaudio.mixers(cardindex=self.cardindex)
+            else:
+                known_controls = alsaaudio.mixers(device=self.device)
         except alsaaudio.ALSAAudioError:
             raise exceptions.MixerError(
-                f"Could not find ALSA soundcard with index {self.cardindex:d}. "
+                f"Could not find ALSA {cardname}. "
                 "Known soundcards include: "
                 f"{', '.join(known_cards)}"
             )
 
         if self.control not in known_controls:
             raise exceptions.MixerError(
-                f"Could not find ALSA mixer control {self.control} on "
-                f"card {self.cardindex:d}. "
-                f"Known mixers on card {self.cardindex:d} include: "
+                f"Could not find ALSA mixer control {self.control} on {cardname}. "
+                f"Known mixers on {cardname} include: "
                 f"{', '.join(known_controls)}"
             )
 
@@ -51,13 +59,14 @@ class AlsaMixer(pykka.ThreadingActor, mixer.Mixer):
         self._last_mute = None
 
         logger.info(
-            f"Mixing using ALSA, card {self.cardindex:d}, "
+            f"Mixing using ALSA, {cardname}, "
             f"mixer control {self.control!r}."
         )
 
     def on_start(self):
         self._observer = AlsaMixerObserver(
             cardindex=self.cardindex,
+            device=self.device,
             control=self.control,
             callback=self.actor_ref.proxy().trigger_events_for_changed_values,
         )
@@ -67,7 +76,16 @@ class AlsaMixer(pykka.ThreadingActor, mixer.Mixer):
     def _mixer(self):
         # The mixer must be recreated every time it is used to be able to
         # observe volume/mute changes done by other applications.
-        return alsaaudio.Mixer(cardindex=self.cardindex, control=self.control)
+        if self.cardindex is not None:
+            return alsaaudio.Mixer(
+                cardindex=self.cardindex,
+                control=self.control,
+            )
+        else:
+            return alsaaudio.Mixer(
+                device=self.device,
+                control=self.control,
+            )
 
     def get_volume(self):
         channels = self._mixer.getvolume()
@@ -168,12 +186,16 @@ class AlsaMixerObserver(threading.Thread):
     daemon = True
     name = "AlsaMixerObserver"
 
-    def __init__(self, cardindex, control, callback=None):
+    def __init__(self, cardindex, device, control, callback=None):
         super().__init__()
         self.running = True
 
         # Keep the mixer instance alive for the descriptors to work
-        self.mixer = alsaaudio.Mixer(cardindex=cardindex, control=control)
+        if cardindex is not None:
+            self.mixer = alsaaudio.Mixer(cardindex=cardindex, control=control)
+        else:
+            self.mixer = alsaaudio.Mixer(device=device, control=control)
+
         descriptors = self.mixer.polldescriptors()
         assert len(descriptors) == 1
         self.fd = descriptors[0][0]

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ install_requires =
     Mopidy >= 3.0.0
     Pykka >= 2.0.1
     setuptools
-    pyalsaaudio
+    pyalsaaudio >= 0.8.0
 
 
 [options.extras_require]

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -12,8 +12,8 @@ class ExtensionTest(unittest.TestCase):
 
         self.assertIn("[alsamixer]", config)
         self.assertIn("enabled = true", config)
-        self.assertIn("card =", config)
         self.assertIn("device = default", config)
+        self.assertIn("card =", config)
         self.assertIn("control = Master", config)
 
     def test_get_config_schema(self):
@@ -21,8 +21,8 @@ class ExtensionTest(unittest.TestCase):
 
         schema = ext.get_config_schema()
 
-        self.assertIn("card", schema)
         self.assertIn("device", schema)
+        self.assertIn("card", schema)
         self.assertIn("control", schema)
 
     def test_setup(self):

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -12,7 +12,8 @@ class ExtensionTest(unittest.TestCase):
 
         self.assertIn("[alsamixer]", config)
         self.assertIn("enabled = true", config)
-        self.assertIn("card = 0", config)
+        self.assertIn("card =", config)
+        self.assertIn("device = default", config)
         self.assertIn("control = Master", config)
 
     def test_get_config_schema(self):
@@ -21,6 +22,7 @@ class ExtensionTest(unittest.TestCase):
         schema = ext.get_config_schema()
 
         self.assertIn("card", schema)
+        self.assertIn("device", schema)
         self.assertIn("control", schema)
 
     def test_setup(self):

--- a/tests/test_mixer.py
+++ b/tests/test_mixer.py
@@ -1,6 +1,8 @@
 import unittest
 from unittest import mock
 
+import copy
+
 import alsaaudio
 
 from mopidy import exceptions
@@ -32,7 +34,7 @@ class MixerTest(unittest.TestCase):
             alsa_mock.cards.return_value = ["PCH"]
             alsa_mock.mixers.return_value = ["Master"]
         if apply_default_config:
-            actual_config = MixerTest.default_config.copy()
+            actual_config = copy.deepcopy(MixerTest.default_config)
             actual_config["alsamixer"].update(config["alsamixer"])
         else:
             actual_config = config
@@ -40,7 +42,7 @@ class MixerTest(unittest.TestCase):
 
     def test_has_config(self, alsa_mock):
         config = {"alsamixer": {"card": 0, "control": "Master"}}
-        actual_config = MixerTest.default_config.copy()
+        actual_config = copy.deepcopy(MixerTest.default_config)
         actual_config["alsamixer"].update(config["alsamixer"])
 
         mixer = self.get_mixer(


### PR DESCRIPTION
At the moment it's not possible to use `mopidy-alsamixer` with virtual ALSA devices because these don't have any cardindex. They can only be targeted using their aliases or string-based names. [More about naming in ALSA.](https://en.wikipedia.org/w/index.php?title=Advanced_Linux_Sound_Architecture&oldid=1065147420#Concepts)

In particular, [bluez-alsa](https://github.com/Arkq/bluez-alsa) backend provides such device aliased as 'bluealsa'. It isn't shown at all in `amixer -l` or `amixer -L`, yet this utility can access them by an alias as `amixer -D bluealsa`. Unfortunately, even with ALSA's configuration files (asound.conf) it's still not possible to target such device with `mopidy-alsamixer` because entries defined there are all virtual devices too, such as `default` device.

This PR fully utilizes remaining [alsaaudio.Mixer](http://larsimmisch.github.io/pyalsaaudio/libalsaaudio.html#alsaaudio.Mixer) `device` argument to broaden scope of soundcards to target.

It's worth mentioning that in this PR I also changed behavior of default configuration. Now It uses device with name `default` instead of the soundcard with index 0, as it allows to use virtual device set as system's default.

   
